### PR TITLE
chore: fix prettier on lint-staged

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,11 +1,5 @@
 export default {
-  "*.ts": () => [
-    "tsc --build tsconfig.build.json",
-    "tsc --build tsconfig.build.json --clean",
-    "eslint --ignore-path .gitignore --fix",
-    "prettier --ignore-path .gitignore --write --ignore-unknown",
-  ],
-  "*.js": [
+  "*.{ts,js}": [
     "eslint --ignore-path .gitignore --fix",
     "prettier --ignore-path .gitignore --write --ignore-unknown",
   ],


### PR DESCRIPTION
no check typescript