### PR TITLE
Specify dependencies version

### DIFF
--- a/packages/build-util/src/index.ts
+++ b/packages/build-util/src/index.ts
@@ -11,9 +11,7 @@ import userscript from "rollup-plugin-userscript";
 import {getPackageMetadata} from "./utils/packageMetadata.js";
 import {getScriptMetadata} from "./utils/scriptMetadata.js";
 
-const isDev = env.NODE_ENV !== "production";
-
-function addSuffix(filename: string, version: string) {
+function addSuffix(filename: string, version: string, isDev = false) {
   const now = new Date().getTime().toString();
 
   if (!isDev) {
@@ -104,6 +102,9 @@ export function rollupConfig({
     esModules: Dependency[];
   }>;
 }> = {}) {
+  const isDev = env.NODE_ENV !== "production";
+  const downloadBaseURL = env.DOWNLOAD_BASE_URL;
+
   const {
     filename: baseFilename,
     version: baseVersion,
@@ -115,7 +116,7 @@ export function rollupConfig({
     dependencies,
   } = getPackageMetadata();
   const extensions = [".ts", ".tsx", ".mjs", ".js", ".jsx"];
-  const {filename, version} = addSuffix(baseFilename, baseVersion);
+  const {filename, version} = addSuffix(baseFilename, baseVersion, isDev);
 
   const cjsModules = externals?.cjsModules ?? [];
   const esModules = externals?.esModules ?? [];
@@ -193,10 +194,10 @@ export function rollupConfig({
               supportURL: tracker,
               homepageURL: homepage,
             },
-            env.DOWNLOAD_BASE_URL
+            downloadBaseURL
               ? {
-                  downloadURL: `${env.DOWNLOAD_BASE_URL}/${filename}.user.js`,
-                  updateURL: `${env.DOWNLOAD_BASE_URL}/${filename}.meta.js`,
+                  downloadURL: `${downloadBaseURL}/${filename}.user.js`,
+                  updateURL: `${downloadBaseURL}/${filename}.meta.js`,
                 }
               : {},
           ),

--- a/packages/build-util/src/index.ts
+++ b/packages/build-util/src/index.ts
@@ -8,7 +8,7 @@ import strip from "@rollup/plugin-strip";
 import importCss from "rollup-plugin-import-css";
 import userscript from "rollup-plugin-userscript";
 
-import {getPackageMetadata} from "./utils/packageMetadata.js";
+import {packageMetadata} from "./utils/packageMetadata.js";
 import {getScriptMetadata} from "./utils/scriptMetadata.js";
 
 function addSuffix(filename: string, version: string, isDev = false) {
@@ -105,18 +105,14 @@ export function rollupConfig({
   const isDev = env.NODE_ENV !== "production";
   const downloadBaseURL = env.DOWNLOAD_BASE_URL;
 
-  const {
-    filename: baseFilename,
-    version: baseVersion,
-    description,
-    license,
-    author,
-    tracker,
-    homepage,
-    dependencies,
-  } = getPackageMetadata();
+  const {description, license, author, tracker, homepage, dependencies} =
+    packageMetadata;
   const extensions = [".ts", ".tsx", ".mjs", ".js", ".jsx"];
-  const {filename, version} = addSuffix(baseFilename, baseVersion, isDev);
+  const {filename, version} = addSuffix(
+    packageMetadata.filename,
+    packageMetadata.version,
+    isDev,
+  );
 
   const cjsModules = externals?.cjsModules ?? [];
   const esModules = externals?.esModules ?? [];


### PR DESCRIPTION
`lit`を`^3.2.1`で指定して v3.3.0 が帰ってきた時にdecoratorが壊れたので、lockしてあるビルド時のバージョンを直接指定するように