### PR TITLE
fix: disable broken CSS minify

### DIFF
--- a/packages/build-util/src/index.ts
+++ b/packages/build-util/src/index.ts
@@ -170,7 +170,7 @@ export function rollupConfig({
         extensions,
       }),
       nodeResolve({browser: false, extensions}),
-      importCss({modules: true, minify: true}),
+      importCss({modules: true, minify: false}),
       strip({
         include: "**/*.ts",
         functions: isDev


### PR DESCRIPTION
broken when using `var()` inside `calc()`. and probably also if another values outside `calc()`.